### PR TITLE
feat: include Nexus.log in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Collects the following information:
    1. The command-line arguments
    1. The currently loaded modules
 1. `arcdps.log` and `arcdps_lastcrash.log` if present
+1. `Nexus.log` if present
 
 ## Screenshots
 

--- a/ui/result/report.go
+++ b/ui/result/report.go
@@ -27,7 +27,8 @@ type Report struct {
 	exitButton        widget.Clickable
 	gw2Dir            string
 	includeDirListing bool
-	includeLogs       bool
+	includeArcdpsLogs bool
+	includeNexusLog   bool
 	dllInfos          []*utils.DllInfo
 	processInfo       *utils.ProcessInfo
 	registryInfo      *registry_check.RegistryInfo
@@ -37,14 +38,15 @@ type Report struct {
 	list              *widget.List
 }
 
-func NewReport(logger *zap.SugaredLogger, gw2Dir string, dllInfos []*utils.DllInfo, processInfo *utils.ProcessInfo, registryInfo *registry_check.RegistryInfo, includeDirListing bool, includeLogs bool) *Report {
+func NewReport(logger *zap.SugaredLogger, gw2Dir string, dllInfos []*utils.DllInfo, processInfo *utils.ProcessInfo, registryInfo *registry_check.RegistryInfo, includeDirListing bool, includeArcdpsLogs bool, includeNexusLog bool) *Report {
 	return &Report{
 		logger:            logger,
 		saveButton:        widget.Clickable{},
 		exitButton:        widget.Clickable{},
 		gw2Dir:            gw2Dir,
 		includeDirListing: includeDirListing,
-		includeLogs:       includeLogs,
+		includeArcdpsLogs: includeArcdpsLogs,
+		includeNexusLog:   includeNexusLog,
 		dllInfos:          dllInfos,
 		processInfo:       processInfo,
 		registryInfo:      registryInfo,
@@ -565,7 +567,7 @@ func (r *Report) saveReport() {
 	}
 
 	// Add this before the directory listing section in generateReport
-	if r.includeLogs {
+	if r.includeArcdpsLogs {
 		// Check for arcdps logs
 		arcdpsLogPath := filepath.Join(r.gw2Dir, "addons/arcdps/arcdps.log")
 		arcdpsCrashLogPath := filepath.Join(r.gw2Dir, "addons/arcdps/arcdps_lastcrash.log")
@@ -588,6 +590,21 @@ func (r *Report) saveReport() {
 			report.WriteString("\n\n")
 		} else {
 			report.WriteString(fmt.Sprintf("Error reading arcdps_lastcrash.log: %s\n\n", err.Error()))
+		}
+	}
+
+	if r.includeNexusLog {
+		nexusLogPath := filepath.Join(r.gw2Dir, "addons/Nexus/Nexus.log")
+
+		report.WriteString("\n=== Nexus Logs ===\n\n")
+
+		// Try to read Nexus.log
+		if logContent, err := os.ReadFile(nexusLogPath); err == nil {
+			report.WriteString("=== Nexus.log ===\n")
+			report.WriteString(string(logContent))
+			report.WriteString("\n\n")
+		} else {
+			report.WriteString(fmt.Sprintf("Error reading Nexus.log: %s\n\n", err.Error()))
 		}
 	}
 

--- a/ui/select_directory/directory.go
+++ b/ui/select_directory/directory.go
@@ -16,16 +16,18 @@ import (
 )
 
 type Directory struct {
-	logger            *zap.SugaredLogger
-	directory         string
-	selectButton      widget.Clickable
-	continueButton    widget.Clickable
-	errorMessage      string
-	isValid           bool
-	fileExplorer      *explorer.Explorer
-	includeDirListing widget.Bool
-	includeLogs       widget.Bool
-	hasArcdpsLogs     bool
+	logger             *zap.SugaredLogger
+	directory          string
+	selectButton       widget.Clickable
+	continueButton     widget.Clickable
+	errorMessage       string
+	isValid            bool
+	fileExplorer       *explorer.Explorer
+	includeDirListing  widget.Bool
+	includeArcdpsLogs  widget.Bool
+	includeNexusLog    widget.Bool
+	hasArcdpsLogs      bool
+	hasNexusLog        bool
 }
 
 func NewDirectory(logger *zap.SugaredLogger) *Directory {
@@ -34,11 +36,12 @@ func NewDirectory(logger *zap.SugaredLogger) *Directory {
 		selectButton:      widget.Clickable{},
 		continueButton:    widget.Clickable{},
 		includeDirListing: widget.Bool{Value: true}, // Include directory listing by default
-		includeLogs:       widget.Bool{Value: true}, // Include logs by default if they exist
+		includeArcdpsLogs: widget.Bool{Value: true}, // Include arcdps logs by default if they exist
+		includeNexusLog:   widget.Bool{Value: true}, // Include Nexus log by default if it exists
 	}
 }
 
-func (d *Directory) Run(w *app.Window, gtx layout.Context, e app.FrameEvent) (bool, string, bool, bool) {
+func (d *Directory) Run(w *app.Window, gtx layout.Context, e app.FrameEvent) (bool, string, bool, bool, bool) {
 	th := material.NewTheme()
 
 	if d.fileExplorer == nil {
@@ -79,7 +82,7 @@ func (d *Directory) Run(w *app.Window, gtx layout.Context, e app.FrameEvent) (bo
 
 	// Continue button clicked and directory is valid
 	if d.continueButton.Clicked(gtx) && d.isValid {
-		return true, d.directory, d.includeDirListing.Value, d.hasArcdpsLogs && d.includeLogs.Value
+		return true, d.directory, d.includeDirListing.Value, d.hasArcdpsLogs && d.includeArcdpsLogs.Value, d.hasNexusLog && d.includeNexusLog.Value
 	}
 
 	layout.Flex{
@@ -135,7 +138,18 @@ func (d *Directory) Run(w *app.Window, gtx layout.Context, e app.FrameEvent) (bo
 		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 			if d.isValid && d.hasArcdpsLogs {
 				// Add checkbox for arcdps logs
-				checkbox := material.CheckBox(th, &d.includeLogs, "Include arcdps logs in report")
+				checkbox := material.CheckBox(th, &d.includeArcdpsLogs, "Include arcdps logs in report")
+				return checkbox.Layout(gtx)
+			}
+			return layout.Dimensions{}
+		}),
+		layout.Rigid(
+			layout.Spacer{Height: 10}.Layout,
+		),
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			if d.isValid && d.hasNexusLog {
+				// Add checkbox for Nexus log
+				checkbox := material.CheckBox(th, &d.includeNexusLog, "Include Nexus log in report")
 				return checkbox.Layout(gtx)
 			}
 			return layout.Dimensions{}
@@ -151,7 +165,7 @@ func (d *Directory) Run(w *app.Window, gtx layout.Context, e app.FrameEvent) (bo
 			return layout.Dimensions{}
 		}))
 
-	return false, "", false, false
+	return false, "", false, false, false
 }
 
 func (d *Directory) validateDirectory() {
@@ -179,6 +193,13 @@ func (d *Directory) validateDirectory() {
 	d.hasArcdpsLogs = err1 == nil || err2 == nil
 	if d.hasArcdpsLogs {
 		d.logger.Infow("Found arcdps logs", "path", d.directory)
+	}
+
+	// Check for Nexus log
+	_, err = os.Stat(path.Join(d.directory, "addons/Nexus/Nexus.log"))
+	d.hasNexusLog = err == nil
+	if d.hasNexusLog {
+		d.logger.Infow("Found Nexus log", "path", d.directory)
 	}
 
 	d.errorMessage = ""

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -33,7 +33,8 @@ type UI struct {
 	// Data passed between screens
 	gw2Directory      string
 	includeDirListing bool
-	includeLogs       bool
+	includeArcdpsLogs bool
+	includeNexusLog   bool
 	dllInfos          []*utils.DllInfo
 	processInfo       *utils.ProcessInfo
 	registryInfo      *registry_check.RegistryInfo
@@ -100,11 +101,12 @@ func (ui *UI) Run(w *app.Window) error {
 				}
 
 			case selectDirectoryState:
-				continueToNextStep, selectedDir, includeDirListing, includeLogs := ui.directoryPicker.Run(w, gtx, e)
+				continueToNextStep, selectedDir, includeDirListing, includeArcdpsLogs, includeNexusLog := ui.directoryPicker.Run(w, gtx, e)
 				if continueToNextStep {
 					ui.gw2Directory = selectedDir
 					ui.includeDirListing = includeDirListing
-					ui.includeLogs = includeLogs
+					ui.includeArcdpsLogs = includeArcdpsLogs
+					ui.includeNexusLog = includeNexusLog
 					ui.dllScanner = scan_directory.NewScanner(ui.Logger, selectedDir, w)
 					ui.currentState = scanDllsState
 				}
@@ -126,7 +128,7 @@ func (ui *UI) Run(w *app.Window) error {
 			case registryCheckState:
 				if ui.registryChecker.Run(gtx, e) {
 					ui.registryInfo = ui.registryChecker.GetRegistryInfo()
-					ui.resultReport = result.NewReport(ui.Logger, ui.gw2Directory, ui.dllInfos, ui.processInfo, ui.registryInfo, ui.includeDirListing, ui.includeLogs)
+					ui.resultReport = result.NewReport(ui.Logger, ui.gw2Directory, ui.dllInfos, ui.processInfo, ui.registryInfo, ui.includeDirListing, ui.includeArcdpsLogs, ui.includeNexusLog)
 					ui.currentState = resultState
 				}
 


### PR DESCRIPTION
Detects addons/Nexus/Nexus.log alongside arcdps logs and adds a separate opt-in checkbox so users with Nexus can include their log in the generated report.